### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/airspy-tools/README.md
+++ b/airspy-tools/README.md
@@ -10,7 +10,7 @@ AirSpy: http://www.airspy.com
 
 For more details on how to build airspy-tools see previous directory host README.md file.
 
-##Principal authors:
+## Principal authors:
 
 Benjamin Vernoux <bvernoux@airspy.com> and Youssef Touil <youssef@airspy.com> 
 

--- a/libairspy/README.md
+++ b/libairspy/README.md
@@ -10,7 +10,7 @@ AirSpy: http://www.airspy.com
 
 For more details on how to build libairspy see previous directory host README.md file.
 
-##Principal authors:
+## Principal authors:
 
 Benjamin Vernoux <bvernoux@airspy.com> and Youssef Touil <youssef@airspy.com> 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
