### PR TITLE
Airspy list devices

### DIFF
--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -901,7 +901,10 @@ int airspy_list_devices(uint64_t *serials, int count)
 	int i;
 	unsigned char serial_number[SERIAL_AIRSPY_EXPECTED_SIZE + 1];
 
-	memset(serials, 0, sizeof(uint64_t) * count);
+	if (serials)
+	{
+		memset(serials, 0, sizeof(uint64_t) * count);
+	}
 
 	if (libusb_init(&context) != 0)
 	{
@@ -915,7 +918,7 @@ int airspy_list_devices(uint64_t *serials, int count)
 
 	i = 0;
 	output_count = 0;
-	while ((dev = devices[i++]) != NULL && output_count < count)
+	while ((dev = devices[i++]) != NULL && (!serials || output_count < count))
 	{
 		libusb_get_device_descriptor(dev, &device_descriptor);
 
@@ -950,7 +953,10 @@ int airspy_list_devices(uint64_t *serials, int count)
 						continue;
 					}
 
-					serials[output_count] = serial;
+					if (serials)
+					{
+						serials[output_count] = serial;
+					}
 					output_count++;
 				}
 

--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -887,6 +887,83 @@ extern "C"
 		return AIRSPY_SUCCESS;
 	}
 
+int airspy_list_devices(uint64_t *serials, int count)
+{
+	libusb_device_handle* libusb_dev_handle;
+	struct libusb_context *context;
+	libusb_device** devices = NULL;
+	libusb_device *dev;
+	struct libusb_device_descriptor device_descriptor;
+
+	int serial_descriptor_index;
+	int serial_number_len;
+	int output_count;
+	int i;
+	unsigned char serial_number[SERIAL_AIRSPY_EXPECTED_SIZE + 1];
+
+	memset(serials, 0, sizeof(uint64_t) * count);
+
+	if (libusb_init(&context) != 0)
+	{
+		return AIRSPY_ERROR_LIBUSB;
+	}
+
+	if (libusb_get_device_list(context, &devices) < 0)
+	{
+		return AIRSPY_ERROR_NOT_FOUND;
+	}
+
+	i = 0;
+	output_count = 0;
+	while ((dev = devices[i++]) != NULL && output_count < count)
+	{
+		libusb_get_device_descriptor(dev, &device_descriptor);
+
+		if ((device_descriptor.idVendor == airspy_usb_vid) &&
+			(device_descriptor.idProduct == airspy_usb_pid))
+		{
+			serial_descriptor_index = device_descriptor.iSerialNumber;
+			if (serial_descriptor_index > 0)
+			{
+				if (libusb_open(dev, &libusb_dev_handle) != 0)
+				{
+					continue;
+				}
+
+				serial_number_len = libusb_get_string_descriptor_ascii(libusb_dev_handle,
+					serial_descriptor_index,
+					serial_number,
+					sizeof(serial_number));
+
+				if (serial_number_len == SERIAL_AIRSPY_EXPECTED_SIZE)
+				{
+					char *start, *end;
+					uint64_t serial;
+
+					serial_number[SERIAL_AIRSPY_EXPECTED_SIZE] = 0;
+					start = (char*)(serial_number + STR_PREFIX_SERIAL_AIRSPY_SIZE);
+					end = NULL;
+					serial = strtoull(start, &end, 16);
+					if (serial == 0 && start == end)
+					{
+						libusb_close(libusb_dev_handle);
+						continue;
+					}
+
+					serials[output_count] = serial;
+					output_count++;
+				}
+
+				libusb_close(libusb_dev_handle);
+			}
+		}
+	}
+
+	libusb_free_device_list(devices, 1);
+	libusb_exit(context);
+	return output_count;
+}
+
 	int ADDCALL airspy_open_sn(airspy_device_t** device, uint64_t serial_number)
 	{
 		int result;

--- a/libairspy/src/airspy.h
+++ b/libairspy/src/airspy.h
@@ -122,7 +122,9 @@ extern ADDAPI void ADDCALL airspy_lib_version(airspy_lib_version_t* lib_version)
 extern ADDAPI int ADDCALL airspy_init(void);
 /* airspy_exit() deprecated */
 extern ADDAPI int ADDCALL airspy_exit(void);
- 
+
+extern ADDAPI int ADDCALL airspy_list_devices(uint64_t *serials, int count);
+
 extern ADDAPI int ADDCALL airspy_open_sn(struct airspy_device** device, uint64_t serial_number);
 extern ADDAPI int ADDCALL airspy_open(struct airspy_device** device);
 extern ADDAPI int ADDCALL airspy_close(struct airspy_device* device);


### PR DESCRIPTION
Add an airspy_list_devices() function copied and adapted from airspyhf+

It also contains the PR2 I submitted to airspyhf+ to be able to pass NULL as serials to airpyhf_list_devices() to only get the number of devices.

This PR would close #48 (including the proposed improvement)

**As I don't have an AirSpy to test it, this PR should first be tested with real AirSpy devices. I only faked an usb device to test it.**