### PR TITLE
explicit path for getopt.c source

### DIFF
--- a/airspy-tools/src/CMakeLists.txt
+++ b/airspy-tools/src/CMakeLists.txt
@@ -25,7 +25,7 @@ set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX"
 
 if(MSVC)
 add_library(libgetopt_static STATIC
-    ../getopt/getopt.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../getopt/getopt.c
 )
 endif()
 


### PR DESCRIPTION
Test cmake 3.19.2 on MSVC 2019. The relative path didnt work. This may have been a change required after a recent cmake update. But when in doubt, the full path is always the best.