### PR TITLE
Process pending libusb events before shutdown

### DIFF
--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -529,7 +529,7 @@ static int kill_io_threads(airspy_device_t* device)
 		pthread_join(device->transfer_thread, NULL);
 		pthread_join(device->consumer_thread, NULL);
 
-		libusb_handle_events_timeout(device->usb_context, &timeout);
+		libusb_handle_events_timeout_completed(device->usb_context, &timeout, NULL);
 
 		device->stop_requested = false;
 		device->streaming = false;

--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -515,6 +515,8 @@ static void* transfer_threadproc(void* arg)
 
 static int kill_io_threads(airspy_device_t* device)
 {
+	struct timeval timeout = { 0, 0 };
+
 	if (device->streaming)
 	{
 		device->stop_requested = true;
@@ -526,6 +528,8 @@ static int kill_io_threads(airspy_device_t* device)
 
 		pthread_join(device->transfer_thread, NULL);
 		pthread_join(device->consumer_thread, NULL);
+
+		libusb_handle_events_timeout(device->usb_context, &timeout);
 
 		device->stop_requested = false;
 		device->streaming = false;


### PR DESCRIPTION
After libusb_cancel_transfer, pending events need to be handled to avoid memory leaks. See issue #77.