### PR TITLE
Fix cmake_minimum_required to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libairspy + airspy-tools
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12.1)
 project (airspy_all)
 
 #provide missing strtoull() for VC11

--- a/airspy-tools/CMakeLists.txt
+++ b/airspy-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12.1)
 project(airspy-tools C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 2)

--- a/libairspy/CMakeLists.txt
+++ b/libairspy/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12.1)
 project(libairspy C)
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/airspy.h AIRSPY_H_CONTENTS)
 


### PR DESCRIPTION
cmake 3.19 warns about dropped compatibility for cmake less than 2.8.12 in the future. This patch sets the minimum required version to what's stated in README.md to avoid the warning.