### PR TITLE
Fix stack buffer overflow in airspy_version_string_read()

### DIFF
--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -1547,7 +1547,7 @@ int airspy_list_devices(uint64_t *serials, int count)
 	{
 #define VERSION_LOCAL_SIZE (128)
 		int result;
-		char version_local[VERSION_LOCAL_SIZE];
+		char version_local[VERSION_LOCAL_SIZE] = "";
 
 		result = libusb_control_transfer(
 			device->usb_device,
@@ -1567,8 +1567,9 @@ int airspy_list_devices(uint64_t *serials, int count)
 		{
 			if (length > 0)
 			{
-				memcpy(version, version_local, length - 1);
-				version[length - 1] = 0;
+				const int num_bytes_to_copy = (length > VERSION_LOCAL_SIZE ? VERSION_LOCAL_SIZE : length) - 1;
+				memcpy(version, version_local, num_bytes_to_copy);
+				version[num_bytes_to_copy] = 0;
 				return AIRSPY_SUCCESS;
 			}
 			else

--- a/libairspy/src/airspy.h
+++ b/libairspy/src/airspy.h
@@ -169,7 +169,7 @@ extern ADDAPI int ADDCALL airspy_spiflash_write(struct airspy_device* device, co
 extern ADDAPI int ADDCALL airspy_spiflash_read(struct airspy_device* device, const uint32_t address, const uint16_t length, unsigned char* data);
 
 extern ADDAPI int ADDCALL airspy_board_id_read(struct airspy_device* device, uint8_t* value);
-/* Parameter length shall be at least 128bytes */
+/* Parameter length shall be at least 128bytes to avoid possible string clipping */
 extern ADDAPI int ADDCALL airspy_version_string_read(struct airspy_device* device, char* version, uint8_t length);
 
 extern ADDAPI int ADDCALL airspy_board_partid_serialno_read(struct airspy_device* device, airspy_read_partid_serialno_t* read_partid_serialno);


### PR DESCRIPTION
If one follows the comment about length needing to be at least 128 and passes string of the maximum possible size of 255 this function used to access stack memory past the local buffer.

Now the local buffer is zeroed out, and only maximum possible number if bytes are copied, taking into account both local buffer and the version string sizes. This makes it possible to pass string buffer both larger or smaller than the local buffer without any memory access past the buffer boundaries.

Adjusted the comment in the header stating that the string needs to be of a certain size to avoid clipping.

There should be no changes from the API or behavior point of view.