### PR TITLE
Only call pthread_join if thread is 'active'

### DIFF
--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -529,8 +529,14 @@ static int kill_io_threads(airspy_device_t* device)
 		pthread_cond_signal(&device->consumer_cv);
 		pthread_mutex_unlock(&device->consumer_mp);
 
-		pthread_join(device->transfer_thread, NULL);
-		pthread_join(device->consumer_thread, NULL);
+		if (device->transfer_thread != 0) {
+		    pthread_join(device->transfer_thread, NULL);
+		    device->transfer_thread = 0;
+		}
+		if (device->consumer_thread != 0) {
+		    pthread_join(device->consumer_thread, NULL);
+		    device->consumer_thread = 0;
+		}
 
 		libusb_handle_events_timeout_completed(device->usb_context, &timeout, NULL);
 	}


### PR DESCRIPTION
pthread_join() segfaults on some Linux distros (typically from the RHEL-line) if called with a thread id of 0. This PR mitigates this. Se #93 for reference. 