### PR TITLE
Set cmake_minimum_required as range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libairspy + airspy-tools
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8.12.1...3.27)
 project (airspy_all)
 
 #provide missing strtoull() for VC11

--- a/airspy-tools/CMakeLists.txt
+++ b/airspy-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8.12.1...3.27)
 project(airspy-tools C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 2)

--- a/libairspy/CMakeLists.txt
+++ b/libairspy/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8.12.1...3.27)
 project(libairspy C)
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/airspy.h AIRSPY_H_CONTENTS)
 


### PR DESCRIPTION
Recent cmake warns that compatibility for older versions will be removed in the future. Since libairspy cmake work just fine with cmake 3.27, setting the minimum required version as a range silences the warning.