### PR TITLE
Minor CMake maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libairspy + airspy-tools
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8...4.0)
 project (airspy_all)
 
 #provide missing strtoull() for VC11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 cmake_minimum_required(VERSION 2.8...4.0)
 project (airspy_all)
 
+include(GNUInstallDirs)
+
 #provide missing strtoull() for VC11
 if(MSVC11)
     add_definitions(-Dstrtoull=_strtoui64)

--- a/airspy-tools/CMakeLists.txt
+++ b/airspy-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8...4.0)
 project(airspy-tools C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 2)

--- a/airspy-tools/src/CMakeLists.txt
+++ b/airspy-tools/src/CMakeLists.txt
@@ -21,7 +21,13 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX")
+if(DEFINED INSTALL_DEFAULT_BINDIR)
+    message(WARNING
+        "INSTALL_DEFAULT_BINDIR is deprecated, use the standard CMAKE_INSTALL_BINDIR instead."
+    )
+else()
+    set(INSTALL_DEFAULT_BINDIR "${CMAKE_INSTALL_BINDIR}")
+endif()
 
 if(MSVC)
 add_library(libgetopt_static STATIC

--- a/libairspy/CMakeLists.txt
+++ b/libairspy/CMakeLists.txt
@@ -99,8 +99,8 @@ ENDIF(CMAKE_CROSSCOMPILING)
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix \${prefix})
-set(libdir \${exec_prefix}/lib${LIB_SUFFIX})
-set(includedir \${prefix}/include)
+set(libdir \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set(includedir \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
 
 CONFIGURE_FILE(
     ${CMAKE_CURRENT_SOURCE_DIR}/libairspy.pc.in
@@ -109,7 +109,7 @@ CONFIGURE_FILE(
 
 INSTALL(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/libairspy.pc
-    DESTINATION lib${LIB_SUFFIX}/pkgconfig
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
 ########################################################################

--- a/libairspy/CMakeLists.txt
+++ b/libairspy/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 2.8...4.0)
 project(libairspy C)
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/airspy.h AIRSPY_H_CONTENTS)
 

--- a/libairspy/src/CMakeLists.txt
+++ b/libairspy/src/CMakeLists.txt
@@ -79,30 +79,26 @@ endif( ${CYGWIN} )
 
 if( ${UNIX} )
    install(TARGETS airspy
-           LIBRARY DESTINATION lib${LIB_SUFFIX}
            COMPONENT sharedlibs
            )
    install(TARGETS airspy-static
-           ARCHIVE DESTINATION lib${LIB_SUFFIX}
            COMPONENT staticlibs
            )
    install(FILES ${c_headers}
-           DESTINATION include/${PROJECT_NAME}
+           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
            COMPONENT headers
            )
 endif( ${UNIX} )
 
 if( ${WIN32} )
    install(TARGETS airspy
-           DESTINATION bin
            COMPONENT sharedlibs
            )
    install(TARGETS airspy-static
-           DESTINATION bin
            COMPONENT staticlibs
            )
    install(FILES ${c_headers}
-           DESTINATION include/${PROJECT_NAME}
+           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
            COMPONENT headers
            )
 endif( ${WIN32} )


### PR DESCRIPTION
- Bump the minimum cmake policies
- Use the standard `GNUInstallDirs` patterns

I would also recommend ditching all of the `Find*.cmake` modules and `cmake_uninstall`, but I will wait for upstream to advise on the state of the project and if such improvements are welcome.