### PR TITLE
Update cmake_minimum_required to 3.5 for cmake 4 compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libairspy + airspy-tools
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 3.5)
 project (airspy_all)
 
 #provide missing strtoull() for VC11
@@ -43,7 +43,7 @@ if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
        ${CMAKE_CURRENT_BINARY_DIR}/airspy-tools/src/libusb-1.0.dll
    COPYONLY)
    endif()
-   
+
    if (NOT DEFINED THREADS_PTHREADS_WIN32_LIBRARY)
    configure_file(
        ${CMAKE_CURRENT_BINARY_DIR}/../libs_win32/pthreadGC2.dll

--- a/airspy-tools/CMakeLists.txt
+++ b/airspy-tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 3.5)
 project(airspy-tools C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 2)

--- a/libairspy/CMakeLists.txt
+++ b/libairspy/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 3.5)
 project(libairspy C)
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/airspy.h AIRSPY_H_CONTENTS)
 


### PR DESCRIPTION
Set cmake_minimum_required to 3.5 for compatibility with cmake 4

From: https://cmake.org/cmake/help/v4.1/command/cmake_minimum_required.html

> Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/v4.1/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/v4.1/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via ...) will produce an error in CMake 4.0 and above.